### PR TITLE
set archflag to fix clang 5.1 buildlibs error

### DIFF
--- a/libs/buildlibs.py
+++ b/libs/buildlibs.py
@@ -23,7 +23,10 @@ def build_libraries():
         print "Building %s..."% lib_name
         # run_setup gave some wonky errors, so we're defaulting to a simple os.system call.
         os.chdir(dirname(setup_script))
-        result = os.system('python2.7 setup.py -q build')
+        # temporary workaround for broken clang 5.1 error: `unknown argument: '-mno-fused-madd'`
+        cmd = ('set -x ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future '
+                '&& python2.7 setup.py -q build')
+        result = os.system(cmd)
         if result > 0:
             raise OSError("Could not build %s" % lib_name)
         os.chdir(libs_root)


### PR DESCRIPTION
see http://stackoverflow.com/q/22313407/470756 for the general flavor of the
error which has to do with system python having an incompatible cflags set
and this error propagating all the way up when setuptools builds a library.

far from ideal, but a good short term fix for getting plotdevice building on
10.9 with python2.7 and xcode 5.1.
