### PR TITLE
prevent exception on typography.Text construction

### DIFF
--- a/plotdevice/gfx/typography.py
+++ b/plotdevice/gfx/typography.py
@@ -61,7 +61,8 @@ class Text(TransformMixin, EffectsMixin, BoundsMixin, StyleMixin, Grob):
         if not isinstance(text, basestring):
             raise DeviceError("text() must be called with a string as its first argument")
         for attr, val in zip(['x','y','width','height'], args):
-            setattr(self, attr, val)
+            if val is not None:
+                setattr(self, attr, val)
 
         # let _screen_transform handle alignment for single-line text
         if self.width is None:


### PR DESCRIPTION
I'm new to plotdevice and was trying out some library examples. I saw quite a few exceptions on code using textwidth. It turned out to be a problem in the  typography.Text constructor when values contained None.

The problem can be easily reproduced by adding the following line to a new plotdevice window and then run it:

`measure('obj')`
