### PR TITLE
avoid exception on display of preferences dialog which prevents it from ...

### DIFF
--- a/plotdevice/gui/preferences.py
+++ b/plotdevice/gui/preferences.py
@@ -70,16 +70,18 @@ def possibleToolLocations():
 
     # try launching a shell to extract the user's path
     if shell:
-        out, _ = Popen([shell,"-l"], stdout=PIPE, stderr=PIPE, stdin=PIPE).communicate("echo $PATH")
-        for path in out.strip().split(':'):
-            path += '/plotdevice'
-            if '/sbin' in path: continue
-            if path.startswith('/bin'): continue
-            if path.startswith('/usr/bin'): continue
-            if path in locations: continue
-            locations.append(path)
+        try:
+            out, _ = Popen([shell,"-l"], stdout=PIPE, stderr=PIPE, stdin=PIPE).communicate("echo $PATH")
+            for path in out.strip().split(':'):
+                path += '/plotdevice'
+                if '/sbin' in path: continue
+                if path.startswith('/bin'): continue
+                if path.startswith('/usr/bin'): continue
+                if path in locations: continue
+                locations.append(path)
+        except:
+            pass
     return locations
-
 
 
 # class defined in PlotDevicePreferences.xib


### PR DESCRIPTION
On a normal mac, the preferences dialog works fine. On my mac it didn't show up when I tried to display it. Maybe it is because I'm using macports. But after handling/ignoring exceptions in the `possibleToolLocations` function, it also worked fine on my machine
