### PR TITLE
prevent single-line scripts from breaking

### DIFF
--- a/plotdevice/run/__init__.py
+++ b/plotdevice/run/__init__.py
@@ -19,7 +19,7 @@ def encoding(src):
 def uncoded(src):
     """Strips out any `# encoding: ???` lines found at the head of the source listing"""
     lines = src.split("\n")
-    for i in range(2):
+    for i in range(min(len(lines), 2)):
         lines[i] = re.sub(r'#.*coding[=:]\s*([-\w.]+)', '#', lines[i])
     return "\n".join(lines)
 


### PR DESCRIPTION
when stripping out `# encoding: ???` lines, `uncoded` assumes a script
will have more than 2 lines and tries to iterate over them even when
they don't exist. 

This changes the behavior of `uncoded` to iterate over at most two lines.
