### PR TITLE
Python3

### DIFF
--- a/app/deps/IO/module.m
+++ b/app/deps/IO/module.m
@@ -4,8 +4,30 @@ PyMethodDef methods[] = {
   {NULL, NULL},
 };
 
+#if PY_MAJOR_VERSION < 3
+
 void initcIO()
   {
     (void)Py_InitModule("cIO", methods);
   }
 
+#else // PY_MAJOR_VERSION >= 3
+
+static struct PyModuleDef moduledef = {
+	PyModuleDef_HEAD_INIT,
+	"cIO",
+	"This is the cIO module",
+	-1,
+	methods,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+};
+
+PyMODINIT_FUNC PyInit_cIO()
+  {
+    return PyModule_Create(&moduledef);
+  }
+
+#endif // PY_MAJOR_VERSION

--- a/app/deps/build.py
+++ b/app/deps/build.py
@@ -2,25 +2,27 @@ import os
 import errno
 from glob import glob
 from os.path import dirname, basename, abspath, isdir, join
+import sys
 
 libs_root = dirname(abspath(__file__))
 
-def mkdirs(newdir, mode=0777):
+def mkdirs(newdir, mode=511): # 511 = 0o777 (octal)
     try: os.makedirs(newdir, mode)
-    except OSError, err:
+    except OSError:
         # Reraise the error unless it's about an already existing directory
+        err = sys.exc_info()[1]
         if err.errno != errno.EEXIST or not isdir(newdir):
             raise
 
 def build_libraries(dst_root):
-    print "Compiling required c-extensions"
+    print("Compiling required c-extensions")
 
     # Store the current working directory for later.
     # Find all setup.py files in the current folder
     setup_scripts = glob('%s/*/setup.py'%libs_root)
     for setup_script in setup_scripts:
         lib_name = basename(dirname(setup_script))
-        print "Building %s..."% lib_name
+        print("Building %s..."% lib_name)
         os.chdir(dirname(setup_script))
         result = os.system('python2.7 setup.py -q build') # call the lib's setup.py
         if result > 0:
@@ -36,18 +38,18 @@ def build_libraries(dst_root):
         lib_name = dirname(dirname(build_dir))
         # print "Copying", lib_name
         cmd = 'cp -R -p %s/* %s' % (build_dir, dst_root)
-        print cmd
+        print(cmd)
         result = os.system(cmd)
         if result > 0:
             raise OSError("Could not copy %s" % lib_name)
 
 def clean_build_files():
-    print "Cleaning all library build files..."
+    print("Cleaning all library build files...")
 
     build_dirs = glob('%s/*/build'%libs_root)
     for build_dir in build_dirs:
         lib_name = dirname(build_dir)
-        print "Cleaning", lib_name
+        print("Cleaning", lib_name)
         os.system('rm -r %s' % build_dir)
 
 if __name__=='__main__':
@@ -61,4 +63,4 @@ if __name__=='__main__':
         elif arg=='clean':
             clean_build_files()
     else:
-        print "usage: python build.py <destination-path>"
+        print("usage: python build.py <destination-path>")

--- a/app/deps/build.py
+++ b/app/deps/build.py
@@ -24,7 +24,7 @@ def build_libraries(dst_root):
         lib_name = basename(dirname(setup_script))
         print("Building %s..."% lib_name)
         os.chdir(dirname(setup_script))
-        result = os.system('python2.7 setup.py -q build') # call the lib's setup.py
+        result = os.system(sys.executable + ' setup.py -q build') # call the lib's setup.py
         if result > 0:
             raise OSError("Could not build %s" % lib_name)
         os.chdir(libs_root)

--- a/app/deps/foundry/module.m
+++ b/app/deps/foundry/module.m
@@ -4,8 +4,31 @@ PyMethodDef methods[] = {
   {NULL, NULL},
 };
 
+#if PY_MAJOR_VERSION < 3
+
 void initcFoundry()
   {
     (void)Py_InitModule("cFoundry", methods);
   }
 
+#else // PY_MAJOR_VERSION >= 3
+
+static struct PyModuleDef moduledef = {
+	PyModuleDef_HEAD_INIT,
+	"cFoundry",
+	"This is the cFoundry module",
+	-1,
+	methods,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+};
+
+PyMODINIT_FUNC PyInit_cFoundry()
+  {
+    return PyModule_Create(&moduledef);
+  }
+
+
+#endif // PY_MAJOR_VERSION

--- a/app/deps/pathmatics/pathmatics.m
+++ b/app/deps/pathmatics/pathmatics.m
@@ -763,7 +763,11 @@ main(int argc, char *argv[])
     Py_Initialize();
 
     /* Add a static module */
+#if PY_MAJOR_VERSION >= 3
+	PyInit_cPathmatics();
+#else
     initcPathmatics();
+#endif
 
     return 0;
 }

--- a/app/deps/pathmatics/pathmatics.m
+++ b/app/deps/pathmatics/pathmatics.m
@@ -715,16 +715,42 @@ static PyMethodDef PathmaticsMethods[] = {
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 
+#if PY_MAJOR_VERSION >= 3
+static struct PyModuleDef PathmaticsModuleDef = {
+	PyModuleDef_HEAD_INIT,
+	"cPathmatics",
+	"This is the cPathmatics module",
+	-1,
+	PathmaticsMethods,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+};
+#endif
+
 PyMODINIT_FUNC
+#if PY_MAJOR_VERSION >= 3
+PyInit_cPathmatics(void)
+#else
 initcPathmatics(void)
+#endif
 {
     PyObject *m;
 
+#if PY_MAJOR_VERSION >= 3
+    m = PyModule_Create(&PathmaticsModuleDef);
+#else
     m = Py_InitModule("cPathmatics", PathmaticsMethods);
+#endif
 
     PathmaticsError = PyErr_NewException("cPathmatics.error", NULL, NULL);
     Py_INCREF(PathmaticsError);
     PyModule_AddObject(m, "error", PathmaticsError);
+
+#if PY_MAJOR_VERSION >= 3
+	return m;
+#endif
 }
 
 int

--- a/plotdevice/context.py
+++ b/plotdevice/context.py
@@ -1,6 +1,8 @@
 # encoding: utf-8
-import os, re, types
-from contextlib import contextmanager, nested
+import sys, os, re, types
+from contextlib import contextmanager
+if sys.version_info < (3,0):
+    from contextlib import nested
 from collections import namedtuple
 from os.path import exists, expanduser
 

--- a/plotdevice/context.py
+++ b/plotdevice/context.py
@@ -1598,7 +1598,7 @@ class _PDFRenderView(NSView):
     # the PDF data.
 
     def initWithCanvas_(self, canvas):
-        super(_PDFRenderView, self).initWithFrame_( ((0, 0), canvas.pagesize) )
+        objc.super(_PDFRenderView, self).initWithFrame_( ((0, 0), canvas.pagesize) )
         self.canvas = canvas
         return self
 

--- a/plotdevice/gfx/colors.py
+++ b/plotdevice/gfx/colors.py
@@ -17,7 +17,7 @@ HSV = HSB = "hsv"
 CMYK = "cmyk"
 GREY = "greyscale"
 
-_CSS_COLORS = json.load(file(rsrc_path('colors.json')))
+_CSS_COLORS = json.load(open(rsrc_path('colors.json')))
 
 class Color(object):
 

--- a/plotdevice/gui/document.py
+++ b/plotdevice/gui/document.py
@@ -24,7 +24,7 @@ class PlotDeviceDocument(NSDocument):
         self.source = None # string read in from file
         self.source_enc = 'utf-8' # or the contents of a coding: comment
         self.script = None # window controller
-        return super(PlotDeviceDocument,self).init()
+        return objc.super(PlotDeviceDocument,self).init()
 
     def makeWindowControllers(self):
         self.script = ScriptController.alloc().initWithWindowNibName_("PlotDeviceDocument")
@@ -49,7 +49,7 @@ class PlotDeviceDocument(NSDocument):
     #
     def setFileURL_(self, url):
         self.stationery = None
-        super(PlotDeviceDocument, self).setFileURL_(url)
+        objc.super(PlotDeviceDocument, self).setFileURL_(url)
 
     def writeToURL_ofType_error_(self, url, tp, err):
         path = url.fileSystemRepresentation()
@@ -73,7 +73,7 @@ class PlotDeviceDocument(NSDocument):
     def updateChangeCount_(self, chg):
         # changes = {0:"NSChangeDone", 1:"NSChangeUndone", 2:"NSChangeCleared", 3:"NSChangeReadOtherContents", 4:"NSChangeAutosaved", 5:"NSChangeRedone", 256:"NSChangeDiscardable", }
         # print changes[chg]
-        super(PlotDeviceDocument, self).updateChangeCount_(chg)
+        objc.super(PlotDeviceDocument, self).updateChangeCount_(chg)
 
     ## Autosave & restoration on re-launch
 
@@ -81,12 +81,12 @@ class PlotDeviceDocument(NSDocument):
         return True
 
     def encodeRestorableStateWithCoder_(self, coder):
-        super(PlotDeviceDocument, self).encodeRestorableStateWithCoder_(coder)
+        objc.super(PlotDeviceDocument, self).encodeRestorableStateWithCoder_(coder)
         if self.stationery and not self.undoManager().canUndo():
             coder.encodeObject_forKey_(self.stationery, "plotdevice:stationery")
 
     def restoreStateWithCoder_(self, coder):
-        super(PlotDeviceDocument, self).restoreStateWithCoder_(coder)
+        objc.super(PlotDeviceDocument, self).restoreStateWithCoder_(coder)
         self.stationery = coder.decodeObjectForKey_("plotdevice:stationery")
         if self.stationery:
             self.script.setStationery_(self.stationery)
@@ -142,7 +142,7 @@ class ScriptController(NSWindowController):
 
     def initWithWindowNibName_(self, nib):
         self._init_state()
-        return super(ScriptController, self).initWithWindowNibName_(nib)
+        return objc.super(ScriptController, self).initWithWindowNibName_(nib)
 
     def _init_state(self):
         self.vm = Sandbox(self)
@@ -222,7 +222,7 @@ class ScriptController(NSWindowController):
                         break
                 it = it.superview()
             coder.encodeObject_forKey_(split_frames, "plotdevice:split_rects")
-        super(ScriptController, self).encodeRestorableStateWithCoder_(coder)
+        objc.super(ScriptController, self).encodeRestorableStateWithCoder_(coder)
 
 
     def restoreStateWithCoder_(self, coder):
@@ -238,7 +238,7 @@ class ScriptController(NSWindowController):
                     if not split_frames:
                         break
                 it = it.superview()
-        super(ScriptController, self).restoreStateWithCoder_(coder)
+        objc.super(ScriptController, self).restoreStateWithCoder_(coder)
 
     ## Window behavior
 

--- a/plotdevice/gui/editor.py
+++ b/plotdevice/gui/editor.py
@@ -3,6 +3,7 @@ import os
 import re
 import json
 import cgi
+import objc
 from pprint import pprint
 from time import time
 from bisect import bisect
@@ -28,7 +29,7 @@ class DraggyWebView(WebView):
         rewrite = u"\n".join([u'"%s"'%u.path() for u in urls] + strs) + u"\n"
         pb.declareTypes_owner_([NSStringPboardType], self)
         pb.setString_forType_(rewrite, NSStringPboardType)
-        return super(DraggyWebView, self).draggingEntered_(sender)
+        return objc.super(DraggyWebView, self).draggingEntered_(sender)
 
     def performDragOperation_(self, sender):
         pb = sender.draggingPasteboard()
@@ -95,7 +96,7 @@ class EditorView(NSView):
             bgcolor = editor_info('colors')['background']
             bgcolor.setFill()
             NSRectFillUsingOperation(rect, NSCompositeCopy)
-        super(EditorView, self).drawRect_(rect)
+        objc.super(EditorView, self).drawRect_(rect)
 
 
     def _jostle(self):
@@ -462,7 +463,7 @@ class OutputTextView(NSTextView):
         # first responder. the `solution' here is to monitor the find bar's field
         # editor and notice when it is detached from the view hierarchy. it then
         # re-sets itself as first responder
-        super(OutputTextView, self).performFindPanelAction_(sender)
+        objc.super(OutputTextView, self).performFindPanelAction_(sender)
         if self._findTimer:
             self._findTimer.invalidate()
         self._findEditor = self.window().firstResponder().superview().superview()

--- a/plotdevice/gui/views.py
+++ b/plotdevice/gui/views.py
@@ -2,6 +2,7 @@
 import sys
 import os
 import traceback
+import objc
 
 from ..lib.cocoa import *
 from ..gfx import Color
@@ -34,7 +35,7 @@ class GraphicsBackdrop(NSView):
             frame.size.height = max(visible.size.height, minsize.height)
             scrollview.horizontalScroller().setControlSize_(1) #NSSmallControlSize
             scrollview.verticalScroller().setControlSize_(1)
-        self = super(GraphicsBackdrop, self).setFrame_(frame)
+        self = objc.super(GraphicsBackdrop, self).setFrame_(frame)
 
     def didAddSubview_(self, subview):
         if isinstance(subview, GraphicsView):
@@ -54,7 +55,7 @@ class GraphicsBackdrop(NSView):
     def drawRect_(self, rect):
         DARK_GREY.setFill()
         NSRectFillUsingOperation(rect, NSCompositeCopy)
-        super(GraphicsBackdrop, self).drawRect_(rect)
+        objc.super(GraphicsBackdrop, self).drawRect_(rect)
 
     def viewFrameDidChange_(self, note):
         self.setFrame_(self.frame())
@@ -247,7 +248,7 @@ class GraphicsView(NSView):
 class FullscreenWindow(NSWindow):
 
     def initWithRect_(self, fullRect):
-        super(FullscreenWindow, self).initWithContentRect_styleMask_backing_defer_(fullRect, NSBorderlessWindowMask, NSBackingStoreBuffered, True)
+        objc.super(FullscreenWindow, self).initWithContentRect_styleMask_backing_defer_(fullRect, NSBorderlessWindowMask, NSBackingStoreBuffered, True)
         return self
 
     def canBecomeKeyWindow(self):
@@ -256,7 +257,7 @@ class FullscreenWindow(NSWindow):
 class FullscreenView(NSView):
 
     def init(self):
-        super(FullscreenView, self).init()
+        objc.super(FullscreenView, self).init()
         self.mousedown = False
         self.keydown = False
         self.key = None

--- a/plotdevice/run/__init__.py
+++ b/plotdevice/run/__init__.py
@@ -1,11 +1,17 @@
 import linecache, re
 from sys import exc_info
+from sys import version_info
 from os.path import abspath, dirname, relpath
 from traceback import format_list, format_exception_only
 from AppKit import NSBundle
 
 def encoding(src):
     """Searches the first two lines of a string looking for an `# encoding: ???` comment."""
+
+    if version_info >= (3, 0):
+        # src consists of bytes. for the analysis here, we assume ascii for the moment.
+        src = src.decode('ascii')
+
     re_enc = re.compile(r'coding[=:]\s*([-\w.]+)')
     for line in src.split('\n')[:2]:
         if not line.strip().startswith('#'):
@@ -18,6 +24,9 @@ def encoding(src):
 
 def uncoded(src):
     """Strips out any `# encoding: ???` lines found at the head of the source listing"""
+    if version_info >= (3, 0):
+        # src consists of bytes. for the analysis here, we assume ascii for the moment.
+        src = src.decode('ascii')
     lines = src.split("\n")
     for i in range(min(len(lines), 2)):
         lines[i] = re.sub(r'#.*coding[=:]\s*([-\w.]+)', '#', lines[i])

--- a/plotdevice/run/__init__.py
+++ b/plotdevice/run/__init__.py
@@ -7,11 +7,6 @@ from AppKit import NSBundle
 
 def encoding(src):
     """Searches the first two lines of a string looking for an `# encoding: ???` comment."""
-
-    if version_info >= (3, 0):
-        # src consists of bytes. for the analysis here, we assume ascii for the moment.
-        src = src.decode('ascii')
-
     re_enc = re.compile(r'coding[=:]\s*([-\w.]+)')
     for line in src.split('\n')[:2]:
         if not line.strip().startswith('#'):
@@ -24,9 +19,6 @@ def encoding(src):
 
 def uncoded(src):
     """Strips out any `# encoding: ???` lines found at the head of the source listing"""
-    if version_info >= (3, 0):
-        # src consists of bytes. for the analysis here, we assume ascii for the moment.
-        src = src.decode('ascii')
     lines = src.split("\n")
     for i in range(min(len(lines), 2)):
         lines[i] = re.sub(r'#.*coding[=:]\s*([-\w.]+)', '#', lines[i])

--- a/plotdevice/run/console.py
+++ b/plotdevice/run/console.py
@@ -77,7 +77,7 @@ class ScriptAppDelegate(NSObject):
             # self.script.setWindowFrameAutosaveName_('plotdevice:%s'%self.opts['file'])
 
             # foreground the window (if -b wasn't passed) and run the script
-            if opts['activate']:
+            if self.opts['activate']:
                 NSApp().activateIgnoringOtherApps_(True)
             self.script.showWindow_(self)
             AppHelper.callAfter(self.script.scriptedRun)

--- a/plotdevice/run/console.py
+++ b/plotdevice/run/console.py
@@ -168,9 +168,16 @@ class ConsoleScript(ScriptController):
     @property
     def unicode_src(self):
         """Read in our script file's contents (honoring its `# encoding: ...` if present)"""
-        src = open(self.path).read()
-        enc = encoding(src) or 'utf-8'
-        return src.decode(enc)
+        if sys.version_info >= (3, 0):
+            src = open(self.path, encoding = 'utf-8').read()
+            enc = encoding(src) or 'utf-8'
+            if enc != 'utf-8':
+                src = open(self.path, encoding = enc).read()
+            return src
+        else:
+            src = open(self.path).read()
+            enc = encoding(src) or 'utf-8'
+            return src.decode(enc)
 
     def scriptedRun(self):
         # this is the first run that gets triggered at invocation

--- a/plotdevice/run/console.py
+++ b/plotdevice/run/console.py
@@ -168,7 +168,7 @@ class ConsoleScript(ScriptController):
     @property
     def unicode_src(self):
         """Read in our script file's contents (honoring its `# encoding: ...` if present)"""
-        src = file(self.path).read()
+        src = open(self.path).read()
         enc = encoding(src) or 'utf-8'
         return src.decode(enc)
 

--- a/plotdevice/run/console.py
+++ b/plotdevice/run/console.py
@@ -156,7 +156,7 @@ class ConsoleScript(ScriptController):
     def init(self):
         self._init_state()
         self._buf = '' # cache the export progress message between stdout writes
-        return super(ScriptController, self).init()
+        return objc.super(ScriptController, self).init()
 
     def setScript_options_(self, path, opts):
         self.vm.path = path
@@ -189,12 +189,12 @@ class ConsoleScript(ScriptController):
     def runScript(self):
         if self.watcher.stale():
             self.vm.source = self.unicode_src
-        super(ConsoleScript, self).runScript()
+        objc.super(ConsoleScript, self).runScript()
 
     def runFullscreen_(self, sender):
         if self.watcher.stale():
             self.vm.source = self.unicode_src
-        super(ConsoleScript, self).runFullscreen_(sender)
+        objc.super(ConsoleScript, self).runFullscreen_(sender)
 
     def windowWillClose_(self, note):
         NSApp().terminate_(self)
@@ -210,12 +210,12 @@ class ConsoleScript(ScriptController):
             STDERR.flush()
 
     def exportFrame(self, status, canvas=None):
-        super(ConsoleScript, self).exportFrame(status, canvas)
+        objc.super(ConsoleScript, self).exportFrame(status, canvas)
         if not status.ok:
             NSApp().delegate().done()
 
     def exportStatus(self, event):
-        super(ConsoleScript, self).exportStatus(event)
+        objc.super(ConsoleScript, self).exportStatus(event)
 
         if event == 'cancelled':
             msg = 'Halted after %i frames. Finishing file I/O...\n' % self.vm.session.added
@@ -230,7 +230,7 @@ class ConsoleScript(ScriptController):
             NSApp().delegate().done()
 
     def exportProgress(self, written, total, cancelled):
-        super(ConsoleScript, self).exportProgress(written, total, cancelled)
+        objc.super(ConsoleScript, self).exportProgress(written, total, cancelled)
 
         if cancelled:
             msg = "%i frames to go..."%(total-written)

--- a/plotdevice/run/sandbox.py
+++ b/plotdevice/run/sandbox.py
@@ -16,7 +16,7 @@ Outcome = namedtuple('Outcome', ['ok', 'output'])
 Output = namedtuple('Output', ['isErr', 'data'])
 
 class Metadata(object):
-    __slots__ = 'args', 'virtualenv', 'first', 'next', 'last', 'loop'
+    __slots__ = 'args', 'virtualenv', 'first', 'metanext', 'last', 'loop'
     def __init__(self, **opts):
         for k,v in opts.items(): setattr(self,k,v)
     def update(self, changes):
@@ -60,7 +60,7 @@ class Sandbox(object):
 
         # control params used during exports and console-based runs
         self._meta = Metadata(args=[], virtualenv=None, # environmant
-                              first=1, next=1, last=None, # runtime
+                              first=1, metanext=1, last=None, # runtime
                               loop=False) # export opts
 
     # .script
@@ -127,7 +127,7 @@ class Sandbox(object):
         # start off with all systems nominal (fingers crossed)
         self.crashed = False
         result = Outcome(True, [])
-        self._meta.next = self._meta.first
+        self._meta.metanext = self._meta.first
         self._anim = None
 
         # if our .source attr has been changed since the last run, compile it now
@@ -161,7 +161,7 @@ class Sandbox(object):
         self.context._resetContext()
 
         # Set the frame/pagenum
-        self.namespace['PAGENUM'] = self.namespace['FRAME'] = self._meta.next
+        self.namespace['PAGENUM'] = self.namespace['FRAME'] = self._meta.metanext
 
         # Run the specified method (or script's top-level if None)
         result = self.call(method)
@@ -188,9 +188,9 @@ class Sandbox(object):
 
             elif method=='draw':
                 # tick the frame ahead after each draw call
-                self._meta.next+=1
-                if self._meta.next > self._meta.last and self._meta.loop:
-                    self._meta.next = self._meta.first
+                self._meta.metanext+=1
+                if self._meta.metanext > (self._meta.last if self._meta.last else 0) and self._meta.loop:
+                    self._meta.metanext = self._meta.first
 
         return result
 
@@ -261,7 +261,7 @@ class Sandbox(object):
 
     def stop(self):
         """Called when an animated run is halted (voluntarily or otherwise)"""
-        # print "stopping at", self._meta.next-1, "of", self._meta.last
+        # print "stopping at", self._meta.metanext-1, "of", self._meta.last
         result = Outcome(True, [])
         if not self.crashed:
             result = self.call("stop")
@@ -320,7 +320,7 @@ class Sandbox(object):
     def _exportFrame(self):
         if self.session.next():
             # step to the proper FRAME value
-            self._meta.next = self.session.next()
+            self._meta.metanext = self.session.next()
 
             # run the draw() function if it exists (or the whole top-level if not)
             result = self.run(method="draw" if self.animated else None)

--- a/plotdevice/run/sandbox.py
+++ b/plotdevice/run/sandbox.py
@@ -359,7 +359,9 @@ class StdIO(object):
             self.isErr = streamname=='stderr'
 
         def write(self, data):
-            if isinstance(data, str):
+            if sys.version_info >= (3, 0):
+                pass # encoding should not happen here, I guess
+            elif isinstance(data, str):
                 try:
                     data = unicode(data, "utf_8", "replace")
                 except UnicodeDecodeError:

--- a/setup.py
+++ b/setup.py
@@ -163,14 +163,17 @@ class BuildDistCommand(sdist):
         remove_tree('plotdevice.egg-info')
         os.unlink('MANIFEST.in')
 
-from distutils.command.build_py import build_py
+if sys.version_info >= (3,0):
+    from distutils.command.build_py import build_py_2to3 as build_py
+else:
+    from distutils.command.build_py import build_py
 class BuildCommand(build_py):
     def run(self):
         # first let the real build_py routine do its thing
         build_py.run(self)
 
         # then compile the extensions into the just-built module
-        self.spawn(['/usr/bin/python', 'app/deps/build.py', abspath(self.build_lib)])
+        self.spawn([sys.executable, 'app/deps/build.py', abspath(self.build_lib)])
 
         # include some ui resources for running a script from the command line
         rsrc_dir = '%s/plotdevice/rsrc'%self.build_lib
@@ -189,7 +192,7 @@ class BuildAppCommand(Command):
     def run(self):
         self.spawn(['xcodebuild'])
         remove_tree('dist/PlotDevice.app.dSYM')
-        print "done building PlotDevice.app in ./dist"
+        print("done building PlotDevice.app in ./dist")
 
 try:
     import py2app
@@ -231,16 +234,16 @@ try:
             self.copy_file("app/plotdevice", BIN)
 
             # success!
-            print "done building PlotDevice.app in ./dist"
+            print("done building PlotDevice.app in ./dist")
 
 except DistributionNotFound:
     # virtualenv doesn't include pyobjc, py2app, etc. in the sys.path for some reason.
     # not being able to access py2app isn't a big deal for 'build', 'app', 'dist', or 'clean'
     # so only abort the build if the 'py2app' command was given
     if 'py2app' in sys.argv:
-        print """setup.py: py2app build failed
+        print("""setup.py: py2app build failed
           Couldn't find the py2app module (perhaps because you've called setup.py from a virtualenv).
-          Make sure you're using the system's /usr/bin/python interpreter for py2app builds."""
+          Make sure you're using the system's /usr/bin/python interpreter for py2app builds.""")
         sys.exit(1)
 
 
@@ -276,7 +279,7 @@ class DistCommand(Command):
         ORIG = 'app/deps/Sparkle-%s/Sparkle.framework'%SPARKLE_VERSION
         SPARKLE = join(APP,'Contents/Frameworks/Sparkle.framework')
         if not exists(ORIG):
-            print "Downloading Sparkle.framework"
+            print("Downloading Sparkle.framework")
             self.mkpath('app/deps')
             os.system('curl -L %s | bunzip2 -c | tar xf - -C app/deps'%SPARKLE_URL)
         self.mkpath(dirname(SPARKLE))
@@ -297,7 +300,7 @@ class DistCommand(Command):
                            timestamp=timestamp())
             json.dump(release, f)
 
-        print "\nBuilt PlotDevice.app, %s, and release.json in ./dist" % basename(ZIP)
+        print("\nBuilt PlotDevice.app, %s, and release.json in ./dist" % basename(ZIP))
 
 ## Run Build ##
 


### PR DESCRIPTION
These changes add basic python3 compatibility to this absolutely fabulous coding tool (i.e. being able to run the plotdevice console with some examples in a pure python3 environment, e.g. "Foliage" and "Hypercube"). All changes should be backward compatible and not break the python2 status - I did a clean Xcode build with my changes with the standard OS X python 2 environment and everything seems to work fine.