### PR TITLE
Additional Typography Fixes

### DIFF
--- a/plotdevice/context.py
+++ b/plotdevice/context.py
@@ -1748,13 +1748,12 @@ class Canvas(object):
         # Allow the canvas to be used with the image() command
         return self._render_to_image()
 
-    def _render_to_image(self, zoom=1.0, flipped=True):
+    def _render_to_image(self, zoom=1.0):
         size = Size(*[int(dim*zoom) for dim in self.pagesize])
         img = NSImage.alloc().initWithSize_(size)
-        img.lockFocusFlipped_(flipped)
+        img.lockFocusFlipped_(True)
         trans = NSAffineTransform.transform()
-        trans.translateXBy_yBy_(0, self.pagesize.height*zoom)
-        trans.scaleXBy_yBy_(zoom,-zoom)
+        trans.scaleXBy_yBy_(zoom,zoom)
         trans.concat()
         self.draw()
         img.unlockFocus()

--- a/plotdevice/gfx/text.py
+++ b/plotdevice/gfx/text.py
@@ -692,7 +692,7 @@ class TextFragment(object):
         indices = list(range(1, len(self.m.regs)))
         if not indices:
             return ()
-        return tuple(m if m else default for m in self.group(*indices))
+        return tuple([m if m else default for m in self.group(*indices)])
 
     def groupdict(self, default=None):
         """Return a dictionary containing all the named subgroups of the match,

--- a/plotdevice/gfx/typography.py
+++ b/plotdevice/gfx/typography.py
@@ -46,8 +46,15 @@ class Font(object):
 
         # collect the attrs from the current font to fill in any gaps
         cur_spec = _ctx._font._spec
+
+        # if called with positional args we're starting over; inherit just the weight and size
+        if args and 'family' in new_spec:
+            cur_spec['width'] = None
+            cur_spec['variant'] = None
+            cur_spec['italic'] = False
+
+        # convert weight & width to integer values
         for axis, num_axis in dict(weight='wgt', width='wid').items():
-            # convert weight & width to integer values
             cur_spec[num_axis] = getattr(_ctx._font._face, num_axis)
             if axis in new_spec:
                 name, val = standardized(axis, new_spec[axis])

--- a/plotdevice/gfx/typography.py
+++ b/plotdevice/gfx/typography.py
@@ -241,7 +241,7 @@ class Family(object):
 
         self._name = family_name(famname)
         self._faces = odict( (f.psname,f) for f in family_members(self._name) )
-        self.encoding = font_encoding(self._faces.keys()[0])
+        self.encoding = font_encoding(list(self._faces.keys())[0])
 
     def __repr__(self):
         contents = ['"%s"'%self._name, ]
@@ -285,7 +285,7 @@ class Family(object):
             if f.variant not in v_names:
                 v_names.append(f.variant)
         if any(v_names) and None in v_names:
-            return tuple(None, *filter(None, v_names))
+            return tuple([None, *filter(None, v_names)])
         return tuple(v_names)
 
     @property

--- a/plotdevice/gui/views.py
+++ b/plotdevice/gui/views.py
@@ -119,7 +119,7 @@ class GraphicsView(NSView):
         y_pct = NSMidY(visible) / NSHeight(oldframe)
 
         # render (and possibly bomb...)
-        ns_image = canvas._render_to_image(self.zoom, flipped=False)
+        ns_image = canvas._render_to_image(self.zoom)
         bitmap = ns_image.layerContentsForContentsScale_(self._dpr)
 
         # resize


### PR DESCRIPTION
### Bugfixes
- NSImage-based rendering doesn't require the same vertical-flip transform as CGImage and text was rendering upside down
- some of the informational attrs on Font (e.g., `variants`) were failing due to python 2-isms

### Misc. Enhancements
- when calling `font()` with a family name as the first positional arg, don't inherit existing italic/variant state (though do continue inheriting size and weight if they're unspecified)