### PR TITLE
fix scaling issue with image export

### DIFF
--- a/plotdevice/gui/widgets.py
+++ b/plotdevice/gui/widgets.py
@@ -376,6 +376,9 @@ class ExportSheet(NSObject):
             format = self.image['format']
             accessory = self.imageAccessory
 
+            # Set the zoom value so that UI reflects the previously stored value
+            self.imageZoom.setStringValue_("%i%%" % self.image['zoom'])
+
             if self.image['single']:
                 self.imageFormat.selectItemAtIndex_(1)
             else:
@@ -442,7 +445,17 @@ class ExportSheet(NSObject):
                 kind, opts = 'movie', self.movieState()
             else:
                 kind, opts = 'image', self.imageState()
-            setattr(self, kind, dict(opts))  # save the options for next time
+            
+            # Convert zoom multiplier back to percentage before saving
+            saved_opts = dict(opts)
+            if 'zoom' in saved_opts:
+                saved_opts['zoom'] = saved_opts['zoom'] * 100
+
+            # Save the modified options (with percentage zoom)
+            setattr(self, kind, saved_opts)
+            print("Export options:", saved_opts)
+            
+            # Continue with the export using the original options (with decimal zoom)
             self.last = os.path.split(fname) # save the path we exported to
             self.script.exportInit(kind, fname, opts)
 

--- a/plotdevice/gui/widgets.py
+++ b/plotdevice/gui/widgets.py
@@ -453,6 +453,7 @@ class ExportSheet(NSObject):
 
             # Save the modified options (with percentage zoom)
             setattr(self, kind, saved_opts)
+            print("Export options:", saved_opts)
             
             # Continue with the export using the original options (with decimal zoom)
             self.last = os.path.split(fname) # save the path we exported to

--- a/plotdevice/gui/widgets.py
+++ b/plotdevice/gui/widgets.py
@@ -376,9 +376,6 @@ class ExportSheet(NSObject):
             format = self.image['format']
             accessory = self.imageAccessory
 
-            # Set the zoom value so that UI reflects the previously stored value
-            self.imageZoom.setStringValue_("%i%%" % self.image['zoom'])
-
             if self.image['single']:
                 self.imageFormat.selectItemAtIndex_(1)
             else:
@@ -445,17 +442,7 @@ class ExportSheet(NSObject):
                 kind, opts = 'movie', self.movieState()
             else:
                 kind, opts = 'image', self.imageState()
-            
-            # Convert zoom multiplier back to percentage before saving
-            saved_opts = dict(opts)
-            if 'zoom' in saved_opts:
-                saved_opts['zoom'] = saved_opts['zoom'] * 100
-
-            # Save the modified options (with percentage zoom)
-            setattr(self, kind, saved_opts)
-            print("Export options:", saved_opts)
-            
-            # Continue with the export using the original options (with decimal zoom)
+            setattr(self, kind, dict(opts))  # save the options for next time
             self.last = os.path.split(fname) # save the path we exported to
             self.script.exportInit(kind, fname, opts)
 

--- a/plotdevice/gui/widgets.py
+++ b/plotdevice/gui/widgets.py
@@ -365,9 +365,8 @@ class ExportSheet(NSObject):
     def awakeFromNib(self):
         self.formats = dict(image=(0, 'pdf', 0,0, 'png', 'jpg', 'heic', 'tiff', 'gif', 0,0, 'pdf', 'eps'), movie=('mov', 'mov', 'gif'))
         self.movie = dict(format='mov', first=1, last=150, fps=30, bitrate=1, loop=0, codec=0)
-        self.image = dict(format='pdf', zoom=100, first=1, last=1, cmyk=False, single=True)
+        self.image = dict(format='pdf', zoom=1.0, first=1, last=1, cmyk=False, single=True)
         self.last = None
-
 
     @objc.python_method
     def beginExport(self, kind):
@@ -464,7 +463,7 @@ class ExportSheet(NSObject):
         fmts = self.formats['image']
         fmt_idx = self.imageFormat.indexOfSelectedItem()
         state = dict(format=fmts[fmt_idx],
-                     zoom=self.image['zoom'] / 100,
+                     zoom=self.image['zoom'],
                      first=1,
                      cmyk=self.imageCMYK.state()==NSOnState,
                      single=fmt_idx==1,
@@ -497,7 +496,7 @@ class ExportSheet(NSObject):
         sender.setIntValue_(0)
 
         self.imageZoomChanged_(None) # reflect any editing in text field
-        pct = self.image['zoom']
+        pct = self.image['zoom'] * 100
 
         if step > 0:
             pct = 100 * ceil((pct + 1) / 100)
@@ -505,16 +504,16 @@ class ExportSheet(NSObject):
             pct = 100 * floor((pct - 1) / 100)
 
         if 0 < pct < 10000:
-            self.image['zoom'] = pct
+            self.image['zoom'] = pct / 100
             self.imageZoom.setStringValue_("%i%%" % pct)
 
     @IBAction
     def imageZoomChanged_(self, sender):
         pct = self.imageZoom.intValue()
         if pct > 0:
-            self.image['zoom'] = pct
+            self.image['zoom'] = pct / 100
         else:
-            pct = self.image['zoom']
+            pct = self.image['zoom'] * 100
         self.imageZoom.setStringValue_("%i%%" % pct)
 
     @IBAction

--- a/plotdevice/gui/widgets.py
+++ b/plotdevice/gui/widgets.py
@@ -453,7 +453,6 @@ class ExportSheet(NSObject):
 
             # Save the modified options (with percentage zoom)
             setattr(self, kind, saved_opts)
-            print("Export options:", saved_opts)
             
             # Continue with the export using the original options (with decimal zoom)
             self.last = os.path.split(fname) # save the path we exported to


### PR DESCRIPTION
Corrects issue where zoom percentages were being stored as a multiplier, meaning the image size was shrinking with each export

![Exporting image with options copy](https://github.com/user-attachments/assets/c005a79c-f2ab-4cbe-b744-53224c5b7856)

The bug was occurring because:
The UI showed zoom as a percentage (e.g., "100%")
The internal state converted this to a decimal (100%/100 → 1.0) for export
This decimal (1.0) was incorrectly saved back to the settings (1%)
On subsequent exports, this value was divided by 100 again (1%/100 → 0.01), resulting in increasingly small images

This has been fixed by converting back to a percentage before saving the zoom value