### PR TITLE
Continuous zoom and direct rendering

### DIFF
--- a/plotdevice/gui/views.py
+++ b/plotdevice/gui/views.py
@@ -467,4 +467,3 @@ class FullscreenView(NSView):
 
 def calc_scaling_factor(width, height, maxwidth, maxheight):
     return min(float(maxwidth) / width, float(maxheight) / height)
-

--- a/plotdevice/gui/views.py
+++ b/plotdevice/gui/views.py
@@ -149,38 +149,25 @@ class GraphicsView(NSView):
     zoom = property(_get_zoom, _set_zoom)
 
     @objc.python_method
-    def findNearestZoomIndex(self, zoom):
-        """Returns the nearest zoom level, and whether we found a direct, exact
-        match or a fuzzy match."""
-        try: # Search for a direct hit first.
-            idx = self.zoomLevels.index(zoom)
-            return idx, True
-        except ValueError: # Can't find the zoom level, try looking at the indexes.
-            idx = 0
-            try:
-                while self.zoomLevels[idx] < zoom:
-                    idx += 1
-            except KeyError: # End of the list
-                idx = len(self.zoomLevels) - 1 # Just return the last index.
-            return idx, False
+    def _findNearestZoomLevel(self, zoom):
+        """Find the nearest zoom level to the given zoom value"""
+        return min(self.zoomLevels, key=lambda x: abs(x - zoom))
 
     @IBAction
     def zoomIn_(self, sender):
-        idx, direct = self.findNearestZoomIndex(self.zoom)
-        # Direct hits are perfect, but indirect hits require a bit of help.
-        # Because of the way indirect hits are calculated, they are already
-        # rounded up to the upper zoom level; this means we don't need to add 1.
-        if direct:
-            idx += 1
-        idx = max(min(idx, len(self.zoomLevels)-1), 0)
-        self.zoom = self.zoomLevels[idx]
+        """Zoom in one level"""
+        current = self._findNearestZoomLevel(self.zoom)
+        idx = self.zoomLevels.index(current)
+        new_idx = min(idx + 1, len(self.zoomLevels) - 1)
+        self.zoom = self.zoomLevels[new_idx]
 
     @IBAction
     def zoomOut_(self, sender):
-        idx, direct = self.findNearestZoomIndex(self.zoom)
-        idx -= 1
-        idx = max(min(idx, len(self.zoomLevels)-1), 0)
-        self.zoom = self.zoomLevels[idx]
+        """Zoom out one level"""
+        current = self._findNearestZoomLevel(self.zoom)
+        idx = self.zoomLevels.index(current)
+        new_idx = max(idx - 1, 0)
+        self.zoom = self.zoomLevels[new_idx]
 
     @IBAction
     def resetZoom_(self, sender):

--- a/plotdevice/gui/views.py
+++ b/plotdevice/gui/views.py
@@ -10,8 +10,6 @@ from ..gfx import Color
 from ..gfx.atoms import KEY_ESC
 from objc import super
 
-DARK_GREY = NSColor.blackColor().blendedColorWithFraction_ofColor_(0.7, NSColor.whiteColor())
-
 class GraphicsBackdrop(NSView):
     """A container that sits between the NSClipView and GraphicsView
 

--- a/plotdevice/lib/cocoa.py
+++ b/plotdevice/lib/cocoa.py
@@ -48,7 +48,7 @@ from AppKit import NSAlert, NSApp, NSAppearance, NSApplication, NSApplicationAct
                    NSTrackingMouseMoved, NSUnboldFontMask, NSUnionRect, NSUnitalicFontMask, NSView, \
                    NSViewFrameDidChangeNotification, NSViewMinXMargin, NSViewWidthSizable, NSWindow, \
                    NSWindowBackingLocationVideoMemory, NSWindowController, NSWindowTabbingModeAutomatic, \
-                   NSWindowTabbingModePreferred, NSWorkspace
+                   NSWindowTabbingModePreferred, NSWorkspace, NSEventModifierFlagCommand
 from Foundation import CIAffineTransform, CIColorMatrix, CIContext, CIFilter, CIImage, CIVector, Foundation, NO, \
                        NSAffineTransform, NSAffineTransformStruct, NSAttributedString, NSAutoreleasePool, NSBundle, \
                        NSData, NSDate, NSDateFormatter, NSFileCoordinator, NSFileHandle, \


### PR DESCRIPTION
This PR adds the ability to continuously zoom in and out on the PlotDevice canvas with a trackpad or mouse. It also improves rendering performance by replacing the bitmap-based approach with directly rendering to the graphic context.

---
Continuous zoom
---

- Added pinch-to-zoom gesture support
- Added Command+scroll for zooming

https://github.com/user-attachments/assets/73c51466-18f0-4461-bee8-3893bb4bfa18

---
Direct render approach
---

Previously, the GraphicsView would pre-render the entire canvas to a bitmap (NSImage) at the current zoom level, convert it to a CALayer's contents, and display that layer. This has been replaced by directly drawing to the view's graphics context, with viewport clipping to only draw the visible portion of the canvas.

This avoids potentially expensive pre-rendering and caching, which can be significantly faster for large scenes or high zoom levels:
<img width="1212" alt="render_comparison" src="https://github.com/user-attachments/assets/013862c7-84d5-400d-981b-c78889b16983" />

This is particularly helpful when working with animations, since each frame draws faster:

https://github.com/user-attachments/assets/c2d587ec-b014-40cb-88e5-a89e318bdde0

**Note**: The old bitmap approach was smoother when scrolling at high zoom (just moving a cached bitmap around instead of redrawing), but overall I think the benefits of direct drawing outweigh this.
